### PR TITLE
migrate struct input_event.time to .input_event_sec and .input_event_usec

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -1100,8 +1100,8 @@ static int input_device_event_update(struct input_device *device, const struct i
                 if (device->repeat_filter == true)
                 {
 		     if (evkey_type[device->current.event_out.code] == EVENTLIRCD_EVKEY_TYPE_KEY) {
-			     time_delta = 1000000 * (device->current.event_out.time.tv_sec  - previous->event_out.time.tv_sec ) +
-			                            (device->current.event_out.time.tv_usec - previous->event_out.time.tv_usec);
+			     time_delta = 1000000 * (device->current.event_out.input_event_sec  - previous->event_out.input_event_sec ) +
+			                            (device->current.event_out.input_event_usec - previous->event_out.input_event_usec);
 			     if (((previous->repeat_count == 0) && (time_delta <  900000)) ||
 			         ((previous->repeat_count == 1) && (time_delta <  500000)) ||
 			         ((previous->repeat_count == 2) && (time_delta <  300000)) ||
@@ -1116,7 +1116,8 @@ static int input_device_event_update(struct input_device *device, const struct i
 		     }
                 }
 		previous->repeat_count++;
-		previous->event_out.time = device->current.event_out.time;
+		previous->event_out.input_event_sec = device->current.event_out.input_event_sec;
+		previous->event_out.input_event_usec = device->current.event_out.input_event_usec;
 		device->current.repeat_count = previous->repeat_count;
 		break;
 	/*


### PR DESCRIPTION
This allows compiling eventlircd as 32-bit userland with the Y2038 safe
options - `-D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64`

ref: https://lkml.org/lkml/2018/1/6/324

struct timeval is not y2038 safe.
All usage of timeval in the kernel will be replaced by
y2038 safe structures.
The change is also necessary as glibc is introducing support
for 32 bit applications to use 64 bit time_t. Without this
change, many applications would incorrectly interpret values
in the struct input_event.
More details about glibc at
https://sourceware.org/glibc/wiki/Y2038ProofnessDesign .

struct input_event maintains time for each input event.
Real time timestamps are not ideal for input as this
time can go backwards as noted in the patch a80b83b7b8
by John Stultz. Hence, having the input_event.time fields
only big enough for monotonic and boot times are
sufficient.

The change leaves the representation of struct input_event as is
on 64 bit architectures. But uses 2 unsigned long values on 32 bit
machines to support real timestamps until year 2106.
This intentionally breaks the ABI on 32 bit architectures and
compat handling on 64 bit architectures.
This is as per maintainer's preference to introduce compile time errors
rather than run into runtime incompatibilities.

The change requires any 32 bit userspace utilities reading or writing
from event nodes to update their reading format to match the new
input_event.