### PR TITLE
fix assert issue with systemd udev

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -1344,7 +1344,9 @@ static int input_device_add(struct udev_device *udev_device)
 		return -1;
 	}
 
-	name = udev_device_get_property_value(udev_device_get_parent(udev_device), "NAME");
+	name = udev_device_get_parent(udev_device);
+	if (name)
+	  name = udev_device_get_property_value(name, "NAME");
 	if ((name != NULL) && (strncmp(name, "\"eventlircd\"", strlen("\"eventlircd\"")) == 0)) {
 		return 0;
 	}


### PR DESCRIPTION
do not call udev_device_get_parent(udev_device_get_parent(dev)) directly as a null return on the parent will cause an assert in udev_device_get_parent

same as:
- https://github.com/Pulse-Eight/libcec/issues/658
- https://github.com/xbmc/xbmc/pull/25324
- https://github.com/Pulse-Eight/libcec/pull/659
- https://github.com/LibreELEC/LibreELEC.tv/pull/8982

fixes: https://forum.libreelec.tv/thread/28677-update-from-20240612-to-20240613-no-ir/